### PR TITLE
Remove state in order to allow for paging

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -38,7 +38,7 @@ var Calendar = React.createClass({
 
   getMonthRange: function () {
     var range, left, right;
-    var focus = this.moment(this.props.date).clone().startOf('month');
+    var focus = this.moment(this.props.date).startOf('month');
     var size = this.getPropOrCtx('size');
     var firstMonth = this.getPropOrCtx('firstMonth') - 1;
 


### PR DESCRIPTION
Changing wouldn't work since the state never got updated. This change entirely relies on props.
## Testing
- Created a simple month paging example and tried to page months
- TODO: test with other calendar configurations
