### PR TITLE
Added child elements of Day to the agenda

### DIFF
--- a/src/Day.js
+++ b/src/Day.js
@@ -38,6 +38,7 @@ var Day = React.createClass({
       return (
         <div key="agenda"
              className={classes()}>
+          {this.props.children}
         </div>
       );
     } else {


### PR DESCRIPTION
This is a small pull request which adds a means to add content to a day element.

I'm not sure what the long-term plan for the `agenda` is, but this pull-request allows any content to be added to the agenda by adding children to the `Day` element, e.g

```
//enable dayAgenda for all days
<Day dayAgenda={true} />

//add some content to today's agenda
<Day date={moment()}>This text will be appended to the agenda div</Day>
```