### PR TITLE
Removed @jsx React.DOM pragma from files

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 "use strict";
 
 var _ = require('lodash');

--- a/src/Day.js
+++ b/src/Day.js
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 "use strict";
 
 var _ = require('lodash');

--- a/src/Month.js
+++ b/src/Month.js
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 "use strict";
 
 var _ = require('lodash');

--- a/src/Week.js
+++ b/src/Week.js
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 "use strict";
 
 var _ = require('lodash');


### PR DESCRIPTION
Since React 0.12.x the `@jsx React.DOM` pragma has been depreciated and this is causing Babel to error out when compiling.

Since `react-calendar` requires React `^0.12.1` as a peerDependency these should now be removed.  This pull request handles that.



> See: http://facebook.github.io/react/blog/2014/10/16/react-v0.12-rc1.html
The @jsx Pragma is Gone!
We have wanted to do this since before we even open sourced React. No more /** @jsx React.DOM */!. The React specific JSX transform assumes you have React in scope (which had to be true before anyway).
>
>JSXTransformer and react-tools have both been updated to account for this.



Related issues in other projects:
https://github.com/callemall/material-ui/issues/364
https://github.com/DynamicTyped/Griddle/issues/109